### PR TITLE
Remove T in snipRange.R dateTime format

### DIFF
--- a/R/snipRange.R
+++ b/R/snipRange.R
@@ -33,7 +33,7 @@ snipRange <- function(x = NULL, start = NULL, end = NULL){
   # If the to argument is null the last record is assumed
   if (is.null(end)){
     end <- as.POSIXct(tail(x$dateTime, 1),
-                      format = "%Y-%m-%dT%H:%M",
+                      format = "%Y-%m-%d %H:%M",
                       tz = "UTC"
     )
   } else {


### PR DESCRIPTION
Tested with the T removed, and everything was working again. Looks like a simple fix (thankfully!)